### PR TITLE
Configure print output to enable display of utf-8 characters in terminal

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -74,6 +74,7 @@ def print_table(data, cols, wide):
     n, r = divmod(len(data), cols)
     pat = '{{:{}}}'.format(wide)
     line = '\n'.join(pat * cols for _ in range(n))
+    sys.stdout.reconfigure(encoding="utf-8")
     print(line.format(*data))
     #last_line = pat * r
     #print(last_line.format(*data[n*cols:]))


### PR DESCRIPTION
This change fixes the following error in `play_puzzle.py` when using Python 3.11 in a Git Bash terminal:
`UnicodeEncodeError: 'charmap' codec can't encode character '\u2713' in position 0: character maps to <undefined>`

## Previous Behavior
![image](https://github.com/philshem/open-spelling-bee/assets/7192837/1ebfdf27-db70-44be-bc24-cf141614105b)

## New Behavior
![image](https://github.com/philshem/open-spelling-bee/assets/7192837/7ef1ee0a-22dc-4e92-9e84-82536ef237c1)

Code for fix found at https://stackoverflow.com/a/60634040/9882940